### PR TITLE
now stringifying/parsing stuff in the 'memory' store

### DIFF
--- a/lib/stores/memory.js
+++ b/lib/stores/memory.js
@@ -101,7 +101,7 @@ function getValue(cache, key) {
 		value = undefined;
 	}
 
-	return value && value.data;
+	return value && value.data && JSON.parse(value.data);
 }
 
 function removeKey(cache, key) {
@@ -117,7 +117,7 @@ function packageData(value, ttl) {
 	}
 	return {
 		expire: expire,
-		data: value
+		data: JSON.stringify(value)
 	};
 }
 


### PR DESCRIPTION
There are some unexpected behaviors in the memory store because things still share the same object reference (which would be unlike any other real-world cache-store). If I modify the object after it comes back from cache, then it's actually modifying the cached object, which seems incorrect. This will force a new object in memory. Thanks @StevenRacz
